### PR TITLE
gr-modtool: Handle missing/empty string defines argument

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/bind_oot_file.py
@@ -34,7 +34,7 @@ args = parser.parse_args()
 
 prefix = args.prefix
 output_dir = args.output_dir
-defines = tuple(','.join(args.defines).split(','))
+defines = tuple([d for d in ','.join(args.defines).split(',') if d])
 includes = ','.join(args.include)
 name = args.module
 


### PR DESCRIPTION
Empty argument leads to ('',) being propagated through to a -D"" argument for castxml.  Which then interprets the next argument as the define, which typically fails because defines can't include - in their name.

## Related Issue
Fixes #6986

## Testing Done
Hand tested.
No automated testing for this area of code.
Very isolated change, no flow on impact expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
